### PR TITLE
The CMake build script used the `LOCALE` variable directly to constru…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,8 @@ set(LOCALE "" CACHE STRING "The locale for the ICU tokenizer (e.g., th, cn, ja)"
 if(LOCALE)
   set(LIB_SUFFIX "_${LOCALE}")
   set(TOKENIZER_NAME "icu_${LOCALE}")
-  set(C_INIT_SUFFIX ${LOCALE})
+  # Sanitize the locale for the C function name, replacing hyphens with underscores.
+  string(REPLACE "-" "_" C_INIT_SUFFIX "${LOCALE}")
 else()
   set(LIB_SUFFIX "")
   set(TOKENIZER_NAME "icu")


### PR DESCRIPTION
The CMake build script used the `LOCALE` variable directly to construct the C initializer function name.

Standard locale identifiers often contain hyphens (e.g., `en-US`), which are not valid characters for C identifiers. This would cause a compilation error when building the extension with such a locale.

This change sanitizes the locale string by replacing hyphens with underscores before using it to form the function name, ensuring the build succeeds with all valid locale formats.